### PR TITLE
Catch ImportError for CKAN config

### DIFF
--- a/ckanext/agsview/plugin.py
+++ b/ckanext/agsview/plugin.py
@@ -2,18 +2,24 @@
 
 import logging
 import ckan.plugins as p
-from ckan.common import config
+
+try:
+    # CKAN 2.7 and later
+    from ckan.common import config
+except ImportError:
+    # CKAN 2.6 and earlier
+    from pylons import config
 
 
 log = logging.getLogger(__name__)
 ignore_empty = p.toolkit.get_validator('ignore_empty')
 
 
-DEFAULT_AGS_FORMATS = ['ags']
+DEFAULT_AGS_FORMATS = ['ags','esri rest']
 
 
 def ags_view_default_basemap_url():
-    return config.get('ckanext.ags_view_default_basemap_url', '')
+    return config.get('ckanext.agsview.default_basemap_url', '')
 
 
 class AGSFSView(p.SingletonPlugin):

--- a/ckanext/agsview/templates/ags_fs_form.html
+++ b/ckanext/agsview/templates/ags_fs_form.html
@@ -1,4 +1,4 @@
 {% import 'macros/form.html' as form %}
 
-{{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../mapservice (if blank ?? )'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
-{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../mapservice (if blank ?? )'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}
+{{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../MapServer/0'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
+{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{x}/{y}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}

--- a/ckanext/agsview/templates/ags_fs_view.html
+++ b/ckanext/agsview/templates/ags_fs_view.html
@@ -2,7 +2,7 @@
   data-module="ags_fs_view"
   id="data-preview"
   data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
-  data-module-path="{{ resource_view.get('ags_url') or '' }}"
+  data-module-path="{{ resource_view.get('ags_url') or c.resource.url }}"
   data-module-basemap="{{ resource_view.get('basemap_url') or h.ags_view_default_basemap_url() }}">
     <h4 class="loading-dialog">
       <div class="loading-spinner"></div>

--- a/ckanext/agsview/templates/ags_ms_form.html
+++ b/ckanext/agsview/templates/ags_ms_form.html
@@ -1,6 +1,6 @@
 
 {% import 'macros/form.html' as form %}
 
-{{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../mapservice (if blank ?? )'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
-{{ form.input('layer_ids', id='field-layer_ids', label=_('layer ids'), placeholder=_('eg. http://.../mapservice (if blank ?? )'), value=data.layer_ids, error=errors.layer_ids, classes=['control-full', 'control-large']) }}
-{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../mapservice (if blank ?? )'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}
+{{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../MapServer'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
+{{ form.input('layer_ids', id='field-layer_ids', label=_('layer ids'), placeholder=_('Leave blank to return all layers'), value=data.layer_ids, error=errors.layer_ids, classes=['control-full', 'control-large']) }}
+{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{x}/{y}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}

--- a/ckanext/agsview/templates/ags_ms_view.html
+++ b/ckanext/agsview/templates/ags_ms_view.html
@@ -3,7 +3,7 @@
   id="data-preview"
   data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
   data-module-layer_ids="{{ resource_view.get('layer_ids') or '' }}"
-  data-module-path="{{ resource_view.get('ags_url') or '' }}"
+  data-module-path="{{ resource_view.get('ags_url') or c.resource.url }}"
   data-module-basemap="{{ resource_view.get('basemap_url') or h.ags_view_default_basemap_url() }}">
     <h4 class="loading-dialog">
       <div class="loading-spinner"></div>


### PR DESCRIPTION
In CKAN 2.7 and later the config object is imported from ckan common.
In CKAN 2.6 and earlier the config object is imported from Pylons.
Also we should set the resource view to use resource url if ags_url is missing.