### PR TITLE
Allow an iframe of this view on the dataset landing page

### DIFF
--- a/ckanext/agsview/templates/ags_fs_view.html
+++ b/ckanext/agsview/templates/ags_fs_view.html
@@ -2,7 +2,7 @@
   data-module="ags_fs_view"
   id="data-preview"
   data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
-  data-module-path="{{ resource_view.get('ags_url') or c.resource.url }}"
+  data-module-path="{{ resource_view.get('ags_url') or resource.url }}"
   data-module-basemap="{{ resource_view.get('basemap_url') or h.ags_view_default_basemap_url() }}">
     <h4 class="loading-dialog">
       <div class="loading-spinner"></div>

--- a/ckanext/agsview/templates/ags_ms_view.html
+++ b/ckanext/agsview/templates/ags_ms_view.html
@@ -3,7 +3,7 @@
   id="data-preview"
   data-module-site_url="{{ h.dump_json(h.url('/', locale='default', qualified=true)) }}"
   data-module-layer_ids="{{ resource_view.get('layer_ids') or '' }}"
-  data-module-path="{{ resource_view.get('ags_url') or c.resource.url }}"
+  data-module-path="{{ resource_view.get('ags_url') or resource.url }}"
   data-module-basemap="{{ resource_view.get('basemap_url') or h.ags_view_default_basemap_url() }}">
     <h4 class="loading-dialog">
       <div class="loading-spinner"></div>


### PR DESCRIPTION
Changed c.resource.url to resource.url to allow an iframe of this view on the dataset page. Usage of the template variable c is apparently discouraged.

This should fix [2](https://github.com/AppGeo/ckanext-agsview/issues/2).