### PR TITLE
Switch the x's and the y's

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ The ArcGIS Feature Layer Viewer provides access to different ArcGIS Feature Laye
 
   ::
 
-    http://gis.cityofboston.gov/arcgis/rest/services/Basemaps/base_map_webmercatorV2/MapServer/tile/{z}/{x}/{y}
+    http://gis.cityofboston.gov/arcgis/rest/services/Basemaps/base_map_webmercatorV2/MapServer/tile/{z}/{y}/{x}
 
 ArcGIS MapService Viewer (ags_ms_view)
 --------------------------------------
@@ -49,7 +49,7 @@ The ArcGIS MapServer Viewer provides access to MapService and the ability to set
 
   ::
 
-    http://gis.cityofboston.gov/arcgis/rest/services/Basemaps/base_map_webmercatorV2/MapServer/tile/{z}/{x}/{y}
+    http://gis.cityofboston.gov/arcgis/rest/services/Basemaps/base_map_webmercatorV2/MapServer/tile/{z}/{y}/{x}
 
 ----------------------------
 Configuration Options (.ini)
@@ -63,7 +63,7 @@ Can accept `Esri basemap name <http://esri.github.io/esri-leaflet/api-reference/
 
 ::
 
-  ckanext.agsview.default_basemap_url = http://example.com/MapServer/tile//{z}/{x}/{y}
+  ckanext.agsview.default_basemap_url = http://example.com/MapServer/tile//{z}/{y}/{x}
 
 
 ------------------------

--- a/ckanext/agsview/templates/ags_fs_form.html
+++ b/ckanext/agsview/templates/ags_fs_form.html
@@ -1,4 +1,4 @@
 {% import 'macros/form.html' as form %}
 
 {{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../MapServer/0'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
-{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{x}/{y}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}
+{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{y}/{x}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}

--- a/ckanext/agsview/templates/ags_ms_form.html
+++ b/ckanext/agsview/templates/ags_ms_form.html
@@ -3,4 +3,4 @@
 
 {{ form.input('ags_url', id='field-ags_url', label=_('ags url'), placeholder=_('eg. http://.../MapServer'), value=data.ags_url, error=errors.ags_url, classes=['control-full', 'control-large']) }}
 {{ form.input('layer_ids', id='field-layer_ids', label=_('layer ids'), placeholder=_('Leave blank to return all layers'), value=data.layer_ids, error=errors.layer_ids, classes=['control-full', 'control-large']) }}
-{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{x}/{y}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}
+{{ form.input('basemap_url', id='field-basemap_url', label=_('basemap url'), placeholder=_('eg. http://.../tile/{z}/{y}/{x}'), value=data.basemap_url, error=errors.basemap_url, classes=['control-full', 'control-large']) }}


### PR DESCRIPTION
Esri basemap services typically have the [tile row and column switched](https://openlayers.org/en/latest/examples/xyz-esri.html), so updating the examples and form helpers would be 💯 