### PR TITLE
Readme update: fix link to source code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To install ckanext-agsview for development:
 1. Clone the source::
 
     cd /usr/lib/ckan/default/src
-    git clone https://github.com/ckan/ckanext-agsview.git
+    git clone https://github.com/AppGeo/ckanext-agsview.git
 
 2. Activate your CKAN virtual environment, for example::
 


### PR DESCRIPTION
The git clone code in the readme is pointing to a non-existing repo.
Fixed it. 